### PR TITLE
feat: add useScrollTrigger, useTransform, useEffectEvent (port of #11)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,14 +14,19 @@
         "@testing-library/react": "^16.1.0",
         "@types/react": "^19.0.0",
         "happy-dom": "^20.0.0",
+        "lenis": "^1.3.19",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tsdown": "^0.21.4",
         "typescript": "^5.4.5",
       },
       "peerDependencies": {
+        "lenis": ">=1.3.0",
         "react": ">=18.0.0",
       },
+      "optionalPeers": [
+        "lenis",
+      ],
     },
     "playground": {
       "name": "playground",
@@ -655,6 +660,8 @@
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "lenis": ["lenis@1.3.23", "", { "peerDependencies": { "@nuxt/kit": ">=3.0.0", "react": ">=17.0.0", "vue": ">=3.0.0" }, "optionalPeers": ["@nuxt/kit", "react", "vue"] }, "sha512-YxYq3TJqj9sJNv0V9SkyQHejt14xwyIwgDaaMK89Uf9SxQfIszu+gTQSSphh6BWlLTNVKvvXAGkg+Zf+oFIevg=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 

--- a/packages/hamo/biome.json
+++ b/packages/hamo/biome.json
@@ -36,6 +36,18 @@
       }
     }
   },
+  "overrides": [
+    {
+      "includes": ["**/use-scroll-trigger/debugger.tsx"],
+      "linter": {
+        "rules": {
+          "a11y": {
+            "noStaticElementInteractions": "off"
+          }
+        }
+      }
+    }
+  ],
   "javascript": {
     "formatter": {
       "quoteStyle": "single",

--- a/packages/hamo/package.json
+++ b/packages/hamo/package.json
@@ -18,6 +18,16 @@
         "default": "./dist/hamo.cjs"
       }
     },
+    "./scroll-trigger/debugger": {
+      "import": {
+        "types": "./dist/use-scroll-trigger/debugger.d.ts",
+        "default": "./dist/use-scroll-trigger/debugger.mjs"
+      },
+      "require": {
+        "types": "./dist/use-scroll-trigger/debugger.d.cts",
+        "default": "./dist/use-scroll-trigger/debugger.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -71,13 +81,20 @@
     "@testing-library/react": "^16.1.0",
     "@types/react": "^19.0.0",
     "happy-dom": "^20.0.0",
+    "lenis": "^1.3.19",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tsdown": "^0.21.4",
     "typescript": "^5.4.5"
   },
   "peerDependencies": {
-    "react": ">=18.0.0"
+    "react": ">=18.0.0",
+    "lenis": ">=1.3.0"
+  },
+  "peerDependenciesMeta": {
+    "lenis": {
+      "optional": true
+    }
   },
   "overrides": {
     "yaml": "^2.9.0"

--- a/packages/hamo/src/index.ts
+++ b/packages/hamo/src/index.ts
@@ -4,6 +4,7 @@ export {
   useDebouncedState,
   useTimeout,
 } from './use-debounce'
+export { useEffectEvent } from './use-effect-event'
 export { useIntersectionObserver } from './use-intersection-observer'
 export { useLazyState } from './use-lazy-state'
 export { useMediaQuery } from './use-media-query'
@@ -11,4 +12,12 @@ export { useObjectFit } from './use-object-fit'
 export type { Rect } from './use-rect'
 export { useRect } from './use-rect'
 export { useResizeObserver } from './use-resize-observer'
+export type { UseScrollTriggerOptions } from './use-scroll-trigger'
+export { useScrollTrigger } from './use-scroll-trigger'
+export type { Transform, TransformRef } from './use-transform'
+export {
+  TransformContext,
+  TransformProvider,
+  useTransform,
+} from './use-transform'
 export { useWindowSize } from './use-window-size'

--- a/packages/hamo/src/use-debounce/index.ts
+++ b/packages/hamo/src/use-debounce/index.ts
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
 } from 'react'
+import { useEffectEvent } from '../use-effect-event'
 
 export type DebouncedFunction<T extends (...args: any[]) => void> = ((
   ...args: Parameters<T>
@@ -44,28 +45,12 @@ function timeout(callback: (...args: any[]) => void, delay: number) {
   return () => clearTimeout(timeout)
 }
 
-// A stable-identity callback that always invokes the latest `callback`. Named
-// to avoid shadowing React's reserved `useEffectEvent` API — this is a plain
-// ref-backed wrapper with none of that hook's call-site restrictions.
-function useStableCallback<T extends (...args: any[]) => any>(callback: T): T {
-  const callbackRef = useRef(callback)
-  callbackRef.current = callback
-
-  const [memoizedCallback] = useState(
-    () =>
-      (...args: Parameters<T>) =>
-        callbackRef.current(...args)
-  )
-
-  return memoizedCallback as T
-}
-
 export function useDebouncedEffect(
   _callback: () => void,
   delay: number,
   deps: DependencyList = []
 ) {
-  const callback = useStableCallback(_callback)
+  const callback = useEffectEvent(_callback)
 
   useEffect(() => {
     return timeout(() => callback(), delay)
@@ -77,7 +62,7 @@ export function useDebouncedCallback<T>(
   delay: number,
   deps: DependencyList = []
 ) {
-  const callback = useStableCallback(_callback)
+  const callback = useEffectEvent(_callback)
 
   const timeoutRef = useRef<ReturnType<typeof timeout> | null>(null)
 

--- a/packages/hamo/src/use-effect-event/README.md
+++ b/packages/hamo/src/use-effect-event/README.md
@@ -1,0 +1,114 @@
+# useEffectEvent
+
+A polyfill for React's experimental [`useEffectEvent`](https://react.dev/reference/react/useEffectEvent) hook. Returns a stable function reference that always calls the latest version of your callback, without needing to be listed in effect dependency arrays.
+
+React's `useEffectEvent` is still experimental and not available in any stable release. This implementation provides the same core behavior for React 17+ projects.
+
+## Usage
+
+```jsx
+import { useEffectEvent } from 'hamo'
+
+function Chat({ url, onMessage }) {
+  const handleMessage = useEffectEvent(onMessage)
+
+  useEffect(() => {
+    const ws = new WebSocket(url)
+    ws.addEventListener('message', handleMessage)
+
+    return () => ws.close()
+  }, [url]) // handleMessage doesn't need to be in deps
+}
+```
+
+## Parameters
+
+- `callback`: The function to wrap. Can accept any arguments and return any value.
+
+## Return Value
+
+A stable function with the same signature as your callback. The identity never changes across renders, but calling it always invokes the latest `callback` from the most recent render.
+
+## How It Works
+
+The hook stores your callback in a ref (updated every render) and returns a memoized wrapper created once via lazy `useState`. The wrapper delegates to the ref on each call, so:
+
+- The returned function has a **stable identity** (same reference every render)
+- It always reads the **latest props and state** at call time
+- It can safely be omitted from effect dependency arrays
+
+## Differences from React's Experimental Version
+
+| | React `useEffectEvent` | hamo `useEffectEvent` |
+|---|---|---|
+| Availability | Experimental, not in stable React | React 17+ |
+| Identity | Intentionally unstable (changes every render) | Stable (same reference every render) |
+| Callable from | Effects and other Effect Events only | Anywhere (effects, event handlers, callbacks) |
+| Lint enforcement | ESLint plugin enforces constraints | No restrictions |
+
+The stable identity in hamo's version is a practical trade-off — it makes the hook more versatile (usable in event handlers, passed as props) while still solving the core problem of reading latest values without re-triggering effects.
+
+## Examples
+
+### Interval with Latest State
+
+```jsx
+import { useEffect, useState } from 'react'
+import { useEffectEvent } from 'hamo'
+
+function Counter() {
+  const [count, setCount] = useState(0)
+  const [step, setStep] = useState(1)
+
+  const onTick = useEffectEvent(() => {
+    setCount((c) => c + step) // always reads latest step
+  })
+
+  useEffect(() => {
+    const id = setInterval(onTick, 1000)
+    return () => clearInterval(id)
+  }, []) // no need to restart interval when step changes
+
+  return (
+    <div>
+      <p>{count}</p>
+      <input
+        type="number"
+        value={step}
+        onChange={(e) => setStep(Number(e.target.value))}
+      />
+    </div>
+  )
+}
+```
+
+### Effect Without Unnecessary Re-runs
+
+```jsx
+import { useEffect } from 'react'
+import { useEffectEvent } from 'hamo'
+
+function Logger({ data, onLog }) {
+  const log = useEffectEvent(onLog)
+
+  useEffect(() => {
+    log(data) // always calls latest onLog
+  }, [data]) // effect only re-runs when data changes, not when onLog changes
+}
+```
+
+### Scroll Listener with Latest Callback
+
+```jsx
+import { useEffect } from 'react'
+import { useEffectEvent } from 'hamo'
+
+function useScroll(callback) {
+  const handler = useEffectEvent(callback)
+
+  useEffect(() => {
+    window.addEventListener('scroll', handler)
+    return () => window.removeEventListener('scroll', handler)
+  }, []) // listener attached once, always calls latest callback
+}
+```

--- a/packages/hamo/src/use-effect-event/index.ts
+++ b/packages/hamo/src/use-effect-event/index.ts
@@ -1,0 +1,16 @@
+import { useRef, useState } from 'react'
+
+export function useEffectEvent<T extends (...args: any[]) => any>(
+  callback: T
+): T {
+  const callbackRef = useRef(callback)
+  callbackRef.current = callback
+
+  const [memoizedCallback] = useState(
+    () =>
+      (...args: Parameters<T>) =>
+        callbackRef.current(...args)
+  )
+
+  return memoizedCallback as T
+}

--- a/packages/hamo/src/use-scroll-trigger/README.md
+++ b/packages/hamo/src/use-scroll-trigger/README.md
@@ -1,0 +1,369 @@
+# useScrollTrigger
+
+A high-performance, transparent scroll progress tracker for React.
+
+GSAP ScrollTrigger is powerful but it's a black box — you hand it an element and hope for the best. `useScrollTrigger` gives you the same scroll-triggered progress tracking with full visibility into how it works, what it reads, and when it fires.
+
+## Philosophy
+
+Every design decision serves performance and transparency:
+
+- **No per-frame DOM reads.** Element positions are computed once (via `useRect`) and cached. GSAP calls `getBoundingClientRect()` on every scroll frame for every trigger — that forces layout recalculation and kills performance on pages with dozens of scroll-driven elements.
+- **No React re-renders.** Progress updates flow through `useLazyState` and refs, never through `setState`. Your scroll callbacks fire at 60fps without touching the React render cycle.
+- **No magic.** You get `progress`, `direction`, `isActive`, and `steps` — raw values you wire up yourself. No hidden timeline binding, no implicit CSS changes, no side effects you didn't ask for.
+- **Composable.** Built on `useRect`, `useLazyState`, `useEffectEvent`, and `useTransform` — hooks you can use independently. If `useScrollTrigger` doesn't do what you want, you have the building blocks to make your own.
+
+### TransformProvider: the trade-off
+
+Because positions are cached (not read per-frame), programmatic transforms on a parent element (like parallax `translateY`) would make the cached position stale. `TransformProvider` solves this — you tell it what you moved, and child scroll triggers compensate automatically.
+
+This is an explicit trade-off: one extra component wrapper in exchange for zero layout thrashing. On a scrollytelling page with 20+ triggers, this is the difference between smooth and janky.
+
+## Usage
+
+```jsx
+import { useScrollTrigger } from 'hamo'
+
+function FadeIn() {
+  const elementRef = useRef(null)
+
+  const [setRef] = useScrollTrigger({
+    onProgress: ({ progress }) => {
+      elementRef.current.style.opacity = `${progress}`
+    },
+  })
+
+  return (
+    <div ref={(node) => { elementRef.current = node; setRef(node) }}>
+      Fades in as you scroll
+    </div>
+  )
+}
+```
+
+## Parameters
+
+### Options
+
+- `start`: (string, default: `'bottom bottom'`) Start position: `"element-position viewport-position"`.
+- `end`: (string, default: `'top top'`) End position: `"element-position viewport-position"`.
+- `offset`: (number, default: `0`) Pixel offset added to element positions.
+- `disabled`: (boolean, default: `false`) Disables the scroll trigger.
+- `onEnter`: (function) Called when entering the trigger zone. Receives `{ progress, direction }`.
+- `onLeave`: (function) Called when leaving the trigger zone. Receives `{ progress, direction }`.
+- `onProgress`: (function) Called on every scroll update. Receives `{ height, isActive, progress, lastProgress, direction, steps }`.
+- `steps`: (number, default: `1`) Subdivides progress into N discrete sub-ranges.
+- `debug`: (boolean | string, default: `false`) Registers the trigger in the debug store. Pass a string to use as label in the Debugger minimap.
+- `rect`: (Rect) External rect from `useRect` — pass this to share a single `useRect` across multiple triggers on the same element.
+
+### Dependencies
+
+- `deps`: (array, default: `[]`) Dependencies that trigger recalculation.
+
+## Return Value
+
+Returns `[setRef, rect]`:
+
+1. `setRef` — Callback ref to attach to the target element.
+2. `rect` — The element's current rect (from `useRect` internally).
+
+## Position Syntax
+
+Format: `"element-position viewport-position"`
+
+| Keyword | Element | Viewport |
+|---------|---------|----------|
+| `top` | Top edge | Top of viewport |
+| `center` | Vertical center | Center of viewport |
+| `bottom` | Bottom edge | Bottom of viewport |
+| `number` | Pixel offset from top | Pixel offset from top |
+
+### Common Combinations
+
+| Start / End | Description |
+|-------------|-------------|
+| `'bottom bottom'` / `'top top'` | Full element traversal (default) |
+| `'bottom bottom'` / `'top center'` | From entering viewport to reaching center |
+| `'center center'` / `'top top'` | From center alignment to reaching top |
+
+## onProgress Callback Data
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `progress` | `number` | Clamped progress from 0 to 1 |
+| `lastProgress` | `number` | Previous progress value |
+| `direction` | `1 \| -1` | Scroll direction (1 = down, -1 = up) |
+| `isActive` | `boolean` | Whether progress is between 0 and 1 |
+| `height` | `number` | Scroll distance in pixels between start and end |
+| `steps` | `number[]` | Array of per-step progress values |
+
+## How It Works
+
+```
+useScrollTrigger
+  ├── useRect()         → computes element position once, caches it
+  ├── useWindowSize()   → viewport height for position keywords
+  ├── useTransform()    → reads parent transform offset (if any)
+  ├── useLenis()        → subscribes to Lenis scroll (or falls back to native)
+  ├── useLazyState()    → tracks progress without re-renders
+  └── useEffectEvent()  → stable callbacks, no effect churn
+
+On every scroll tick:
+  1. Read scroll position (from Lenis or window.scrollY)
+  2. Subtract parent transform offset (from TransformProvider)
+  3. Map scroll into [0, 1] progress using cached element position
+  4. Fire onEnter/onLeave/onProgress if progress changed
+  5. Zero DOM reads. Zero re-renders.
+```
+
+## Examples
+
+### Enter / Leave with Direction
+
+```jsx
+import { useScrollTrigger } from 'hamo'
+
+function Section() {
+  const [setRef] = useScrollTrigger({
+    onEnter: ({ direction }) => {
+      console.log(direction === 1 ? 'Entered scrolling down' : 'Entered scrolling up')
+    },
+    onLeave: ({ direction }) => {
+      console.log(direction === 1 ? 'Left scrolling down' : 'Left scrolling up')
+    },
+  })
+
+  return <div ref={setRef}>Tracked section</div>
+}
+```
+
+### Steps for Staggered Animations
+
+```jsx
+import { useRef } from 'react'
+import { useScrollTrigger } from 'hamo'
+
+function StaggeredList() {
+  const itemRefs = useRef([])
+
+  const [setRef] = useScrollTrigger({
+    steps: 5,
+    onProgress: ({ steps }) => {
+      steps.forEach((stepProgress, i) => {
+        if (itemRefs.current[i]) {
+          itemRefs.current[i].style.opacity = `${stepProgress}`
+          itemRefs.current[i].style.transform = `translateY(${(1 - stepProgress) * 20}px)`
+        }
+      })
+    },
+  })
+
+  return (
+    <ul ref={setRef}>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <li key={i} ref={(el) => { itemRefs.current[i] = el }}>
+          Item {i + 1}
+        </li>
+      ))}
+    </ul>
+  )
+}
+```
+
+### With Lenis
+
+When Lenis is installed, the hook automatically uses it. No configuration needed.
+
+```jsx
+import { ReactLenis } from 'lenis/react'
+import { useScrollTrigger } from 'hamo'
+
+function App() {
+  return (
+    <ReactLenis root>
+      <AnimatedSection />
+    </ReactLenis>
+  )
+}
+
+function AnimatedSection() {
+  const elementRef = useRef(null)
+
+  const [setRef] = useScrollTrigger({
+    onProgress: ({ progress }) => {
+      elementRef.current.style.transform = `translateX(${progress * 100}px)`
+    },
+  })
+
+  return (
+    <div ref={(node) => { elementRef.current = node; setRef(node) }}>
+      Slides in with smooth scroll
+    </div>
+  )
+}
+```
+
+### CSS Custom Property
+
+```jsx
+import { useScrollTrigger } from 'hamo'
+
+function ParallaxSection() {
+  const elementRef = useRef(null)
+
+  const [setRef] = useScrollTrigger({
+    onProgress: ({ progress }) => {
+      elementRef.current.style.setProperty('--progress', `${progress}`)
+    },
+  })
+
+  return (
+    <div
+      ref={(node) => { elementRef.current = node; setRef(node) }}
+      style={{ transform: 'translateY(calc(var(--progress, 0) * -50px))' }}
+    >
+      Parallax content
+    </div>
+  )
+}
+```
+
+### With TransformProvider (Parallax Compensation)
+
+When a parent is translated programmatically, child scroll triggers need to know. Wrap the parent in `TransformProvider` and report your transforms — children compensate automatically.
+
+```jsx
+import { useRef } from 'react'
+import { useScrollTrigger, TransformProvider } from 'hamo'
+import type { TransformRef } from 'hamo'
+
+function ParallaxWrapper({ children }) {
+  const transformRef = useRef<TransformRef>(null)
+  const elementRef = useRef(null)
+
+  const [setRef] = useScrollTrigger({
+    onProgress: ({ progress }) => {
+      const y = (progress - 0.5) * -100
+      transformRef.current?.setTranslate(0, y)
+      elementRef.current.style.transform = `translateY(${y}px)`
+    },
+  })
+
+  return (
+    <TransformProvider ref={transformRef}>
+      <div ref={(node) => { elementRef.current = node; setRef(node) }}>
+        {children}
+      </div>
+    </TransformProvider>
+  )
+}
+
+function ChildTrigger() {
+  const [setRef] = useScrollTrigger({
+    onProgress: ({ progress }) => {
+      // Accurate despite parent parallax — no getBoundingClientRect needed
+      console.log('progress:', progress)
+    },
+  })
+
+  return <div ref={setRef}>Child content</div>
+}
+
+function Page() {
+  return (
+    <ParallaxWrapper>
+      <ChildTrigger />
+    </ParallaxWrapper>
+  )
+}
+```
+
+### Progressive Text Reveal
+
+```jsx
+import { useRef } from 'react'
+import { useScrollTrigger } from 'hamo'
+
+function TextReveal({ text }) {
+  const containerRef = useRef(null)
+  const words = text.split(' ')
+
+  const [setRef] = useScrollTrigger({
+    start: 'bottom bottom',
+    end: 'center center',
+    steps: words.length,
+    onProgress: ({ steps }) => {
+      if (!containerRef.current) return
+      const spans = containerRef.current.querySelectorAll('span')
+      spans.forEach((span, i) => {
+        span.style.opacity = `${steps[i]}`
+      })
+    },
+  })
+
+  return (
+    <p ref={(node) => { containerRef.current = node; setRef(node) }}>
+      {words.map((word, i) => (
+        <span key={i} style={{ opacity: 0 }}>
+          {word}{' '}
+        </span>
+      ))}
+    </p>
+  )
+}
+```
+
+## Debugger
+
+A minimap overlay that visualizes all active scroll triggers on the page. Each trigger with `debug` enabled appears as a colored rectangle (element position) and a bar (start/end range). Hover a rectangle to see a tooltip with the trigger's id, start/end positions, progress, and active state.
+
+```jsx
+import { Debugger } from 'hamo/scroll-trigger'
+
+function App() {
+  return (
+    <>
+      <Debugger theme="light" />
+      {/* your content */}
+    </>
+  )
+}
+```
+
+### Props
+
+- `theme`: (`'light' | 'dark'`, default: `'dark'`) Color theme.
+
+### How it works
+
+Triggers with `debug` enabled register themselves in a shared store. The Debugger subscribes to that store and renders a fixed minimap that:
+
+- Mirrors the page body shape using the body's aspect ratio
+- Scrolls in sync via a CSS custom property (`--p`)
+- Shows each trigger's element as a colored rectangle, offset by `translateY` from `TransformProvider`
+- Shows each trigger's start/end scroll range as a colored bar aligned to its element
+- Displays a tooltip on hover with trigger details (id, start, end, progress, active)
+
+### Enabling debug on a trigger
+
+```jsx
+const [setRef] = useScrollTrigger({
+  start: 'bottom bottom',
+  end: 'top top',
+  debug: 'my-section', // label shown in tooltip
+  onProgress: ({ progress }) => { /* ... */ },
+})
+```
+
+## vs GSAP ScrollTrigger
+
+| | GSAP ScrollTrigger | useScrollTrigger |
+|---|---|---|
+| DOM reads per frame | `getBoundingClientRect()` on every tick | Zero — positions cached via `useRect` |
+| React re-renders | N/A (not React-aware) | Zero — updates via refs and `useLazyState` |
+| Lenis integration | Manual `scrollerProxy` setup | Automatic |
+| Transform awareness | Implicit (reads DOM) | Explicit via `TransformProvider` |
+| Bundle size | ~55KB (GSAP core + plugin) | ~1KB (inlined in hamo) |
+| Pinning, scrub, snap | Yes | No — use GSAP for those |
+| License | Custom (restrictions on some commercial use) | MIT |
+| Transparency | Black box | Every hook is composable and inspectable |

--- a/packages/hamo/src/use-scroll-trigger/debugger.tsx
+++ b/packages/hamo/src/use-scroll-trigger/debugger.tsx
@@ -1,0 +1,207 @@
+'use client'
+
+import { useLenis } from 'lenis/react'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
+import { useWindowSize } from '../use-window-size'
+import { scrollTriggerStore } from './store'
+
+const COLORS = [
+  '#3b82f6',
+  '#a855f7',
+  '#f59e0b',
+  '#14b8a6',
+  '#f97316',
+  '#ec4899',
+]
+
+const BAR_W = 4
+
+interface DebuggerProps {
+  theme?: 'light' | 'dark'
+}
+
+export function Debugger({ theme = 'dark' }: DebuggerProps) {
+  const fg = theme === 'dark' ? '0,0,0' : '255,255,255'
+  const bg = theme === 'dark' ? '255,255,255' : '0,0,0'
+  const [hovered, setHovered] = useState<string | null>(null)
+  const ref = useRef<HTMLDivElement | null>(null)
+  const lenis = useLenis()
+  const { width: ww = 0, height: wh = 0 } = useWindowSize()
+
+  const triggers = useSyncExternalStore(
+    (cb) => scrollTriggerStore.subscribe(cb),
+    () => scrollTriggerStore.getSnapshot(),
+    () => scrollTriggerStore.getSnapshot()
+  )
+
+  useEffect(() => {
+    function update() {
+      if (!ref.current) return
+      const docH = lenis
+        ? lenis.limit + wh
+        : document.documentElement.scrollHeight
+      const scroll = lenis ? lenis.scroll : window.scrollY
+      const p = docH > wh ? scroll / (docH - wh) : 0
+      ref.current.style.setProperty('--p', p.toString())
+    }
+
+    update()
+
+    if (lenis) {
+      lenis.on('scroll', update)
+      return () => {
+        lenis.off('scroll', update)
+      }
+    }
+
+    window.addEventListener('scroll', update, { passive: true })
+    return () => {
+      window.removeEventListener('scroll', update)
+    }
+  }, [lenis, wh])
+
+  useEffect(() => {
+    if (!ref.current) return
+    const ro = new ResizeObserver(([e]) => {
+      if (!e || !ref.current) return
+      ref.current.style.setProperty(
+        '--br',
+        (e.contentRect.width / e.contentRect.height).toFixed(4)
+      )
+    })
+    ro.observe(document.body)
+    return () => ro.disconnect()
+  }, [])
+
+  const vr = ww && wh ? ww / wh : 1
+  const h = 200 / vr
+  const docH = lenis
+    ? lenis.limit + wh
+    : typeof document !== 'undefined'
+      ? document.documentElement.scrollHeight
+      : 1
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        position: 'fixed',
+        top: '50%',
+        right: 48,
+        width: 200,
+        height: h,
+        transform: 'translateY(-50%)',
+        zIndex: 99999,
+        fontFamily: 'ui-monospace, monospace',
+        fontSize: 10,
+      }}
+    >
+      {/* Body */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          aspectRatio: 'var(--br)',
+          transform: `translateY(calc(var(--p) * -100% + var(--p) * ${h}px))`,
+          background: `rgba(${fg},0.1)`,
+          backdropFilter: 'blur(4px)',
+          borderRadius: 4,
+        }}
+      >
+        {triggers.map((t, i) => {
+          const color = COLORS[i % COLORS.length]
+          const top = ((t.rect.top + t.translateY) / docH) * 100
+          const left = (t.rect.left / ww) * 100
+          const w = (t.rect.width / ww) * 100
+          const rh = (t.rect.height / docH) * 100
+          const startPct = ((t.startPx + t.translateY) / docH) * 100
+          const endPct = ((t.endPx + t.translateY) / docH) * 100
+          const barTop = Math.min(startPct, endPct)
+          const barH = Math.abs(endPct - startPct)
+
+          const isHovered = hovered === t.id
+
+          return (
+            <div key={t.id} style={{ zIndex: isHovered ? 1 : 0 }}>
+              {/* Element rectangle */}
+              <div
+                onMouseEnter={() => setHovered(t.id)}
+                onMouseLeave={() => setHovered(null)}
+                style={{
+                  position: 'absolute',
+                  top: `${top}%`,
+                  left: `${left}%`,
+                  width: `${w}%`,
+                  height: `${rh}%`,
+                  border: `1px solid ${color}`,
+                  opacity: isHovered ? 1 : t.isActive ? 0.8 : 0.2,
+                  transition: 'opacity 150ms',
+                  backgroundColor: `rgba(${fg},0.1)`,
+                  cursor: 'default',
+                  zIndex: isHovered ? 1 : 0,
+                }}
+              >
+                {/* Tooltip */}
+                {isHovered && (
+                  <div
+                    style={{
+                      position: 'absolute',
+                      bottom: '100%',
+                      left: 0,
+                      marginBottom: 4,
+                      padding: '4px 6px',
+                      background: `rgba(${bg},0.9)`,
+                      color: `rgb(${fg})`,
+                      borderRadius: 3,
+                      whiteSpace: 'nowrap',
+                      lineHeight: 1.4,
+                      pointerEvents: 'none',
+                    }}
+                  >
+                    <strong>{t.id}</strong>
+                    <br />
+                    start: {t.start} ({Math.round(t.startPx)}px)
+                    <br />
+                    end: {t.end} ({Math.round(t.endPx)}px)
+                    <br />
+                    progress: {t.progress.toFixed(3)}
+                    <br />
+                    active: {t.isActive ? 'true' : 'false'}
+                  </div>
+                )}
+              </div>
+              {/* Bar */}
+              <div
+                style={{
+                  position: 'absolute',
+                  top: `${barTop}%`,
+                  left: `${left}%`,
+                  width: BAR_W,
+                  height: `${barH}%`,
+                  minHeight: 4,
+                  borderRadius: BAR_W / 2,
+                  background: color,
+                  opacity: isHovered ? 1 : t.isActive ? 0.9 : 0.3,
+                  transition: 'opacity 150ms',
+                }}
+              />
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Border */}
+      <div
+        style={{
+          position: 'absolute',
+          inset: -6,
+          border: `1px solid rgba(${fg},0.5)`,
+          borderRadius: 6,
+          pointerEvents: 'none',
+        }}
+      />
+    </div>
+  )
+}

--- a/packages/hamo/src/use-scroll-trigger/index.ts
+++ b/packages/hamo/src/use-scroll-trigger/index.ts
@@ -1,0 +1,347 @@
+'use client'
+
+import { useLenis } from 'lenis/react'
+import { useEffect, useId, useRef } from 'react'
+import { useEffectEvent } from '../use-effect-event'
+import { useLazyState } from '../use-lazy-state'
+import { type Rect, useRect } from '../use-rect'
+import { useTransform } from '../use-transform'
+import { useWindowSize } from '../use-window-size'
+import { scrollTriggerStore } from './store'
+
+// Math utilities (inlined to avoid external dependency)
+function clamp(min: number, input: number, max: number): number {
+  return Math.max(min, Math.min(input, max))
+}
+
+function mapRange(
+  inMin: number,
+  inMax: number,
+  input: number,
+  outMin: number,
+  outMax: number
+): number {
+  return ((input - inMin) * (outMax - outMin)) / (inMax - inMin) + outMin
+}
+
+function isNumber(value: unknown): value is number {
+  return typeof value === 'number' || !Number.isNaN(value)
+}
+
+export function modulo(n: number, d: number) {
+  if (d === 0) return n
+  if (d < 0) return Number.NaN
+  return ((n % d) + d) % d
+}
+
+type TriggerPosition = 'top' | 'center' | 'bottom' | number
+type TriggerPositionCombination = `${TriggerPosition} ${TriggerPosition}`
+
+export type UseScrollTriggerOptions = {
+  /** External rect from useRect — pass this to share a single useRect across multiple triggers on the same element */
+  rect?: Rect
+  /** Start position: "element-position viewport-position" (default: "bottom bottom") */
+  start?: TriggerPositionCombination
+  /** End position: "element-position viewport-position" (default: "top top") */
+  end?: TriggerPositionCombination
+  /** Pixel offset added to element positions */
+  offset?: number
+  /** Disable the scroll trigger */
+  disabled?: boolean
+  /** Called when element enters the trigger zone */
+  onEnter?: (data: { progress: number; direction: 1 | -1 }) => void
+  /** Called when element leaves the trigger zone */
+  onLeave?: (data: { progress: number; direction: 1 | -1 }) => void
+  /** Called on every scroll progress update */
+  onProgress?: (data: {
+    height: number
+    isActive: boolean
+    progress: number
+    lastProgress: number
+    direction: 1 | -1
+    steps: number[]
+  }) => void
+  /** Number of discrete steps to subdivide progress into */
+  steps?: number
+  /** Enable debug mode — registers this trigger to the Minimap. Pass a string to use as label. */
+  debug?: boolean | string
+}
+
+/**
+ * Hook for creating scroll-based animations and triggers.
+ *
+ * Provides scroll-triggered progress tracking with GSAP ScrollTrigger-like
+ * position syntax. Integrates with Lenis when available, falls back to
+ * native scroll events.
+ *
+ * Position format: "element-position viewport-position"
+ * Available positions: 'top', 'center', 'bottom', or pixel values
+ *
+ * @param options - Configuration options
+ * @param deps - Dependencies that trigger recalculation
+ *
+ * @returns [setRef, rect] - A ref setter (undefined if external rect provided) and the element's rect
+ *
+ * @example
+ * ```tsx
+ * // Basic usage — creates its own useRect internally
+ * const [setRef] = useScrollTrigger({
+ *   onProgress: ({ progress }) => console.log(progress),
+ * })
+ * return <div ref={setRef}>...</div>
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Shared rect — multiple triggers on the same element, single useRect
+ * const [setRef, rect] = useRect()
+ * useScrollTrigger({ rect, end: 'center center', onEnter: handleEnter })
+ * useScrollTrigger({ rect, start: 'center center', onProgress: handleParallax })
+ * return <div ref={setRef}>...</div>
+ * ```
+ */
+export function useScrollTrigger(
+  {
+    rect: externalRect,
+    start = 'bottom bottom',
+    end = 'top top',
+    offset = 0,
+    disabled = false,
+    onEnter,
+    onLeave,
+    onProgress,
+    steps = 1,
+    debug = false,
+  }: UseScrollTriggerOptions = {},
+  deps: unknown[] = []
+) {
+  const [setRectRef, internalRect] = useRect({})
+  const rect = externalRect ?? internalRect
+  const getTransform = useTransform()
+  const lenis = useLenis()
+  const autoId = useId()
+  const debugId = typeof debug === 'string' ? debug : autoId
+  const debugRef = useRef(debug)
+
+  const { height: windowHeight = 0 } = useWindowSize()
+
+  const isReady = rect?.top !== undefined
+
+  const [elementStartKeyword, viewportStartKeyword] =
+    typeof start === 'string' ? start.split(' ') : [start]
+  const [elementEndKeyword, viewportEndKeyword] =
+    typeof end === 'string' ? end.split(' ') : [end]
+
+  let viewportStart = isNumber(viewportStartKeyword)
+    ? Number.parseFloat(viewportStartKeyword as string)
+    : 0
+  if (viewportStartKeyword === 'top') viewportStart = 0
+  if (viewportStartKeyword === 'center') viewportStart = windowHeight * 0.5
+  if (viewportStartKeyword === 'bottom') viewportStart = windowHeight
+
+  let viewportEnd = isNumber(viewportEndKeyword)
+    ? Number.parseFloat(viewportEndKeyword as string)
+    : 0
+  if (viewportEndKeyword === 'top') viewportEnd = 0
+  if (viewportEndKeyword === 'center') viewportEnd = windowHeight * 0.5
+  if (viewportEndKeyword === 'bottom') viewportEnd = windowHeight
+
+  let elementStart = isNumber(elementStartKeyword)
+    ? Number.parseFloat(elementStartKeyword as string)
+    : rect?.bottom || 0
+  if (elementStartKeyword === 'top') elementStart = rect?.top || 0
+  if (elementStartKeyword === 'center')
+    elementStart = (rect?.top || 0) + (rect?.height || 0) * 0.5
+  if (elementStartKeyword === 'bottom') elementStart = rect?.bottom || 0
+
+  elementStart += offset
+
+  let elementEnd = isNumber(elementEndKeyword)
+    ? Number.parseFloat(elementEndKeyword as string)
+    : rect?.top || 0
+  if (elementEndKeyword === 'top') elementEnd = rect?.top || 0
+  if (elementEndKeyword === 'center')
+    elementEnd = (rect?.top || 0) + (rect?.height || 0) * 0.5
+  if (elementEndKeyword === 'bottom') elementEnd = rect?.bottom || 0
+
+  elementEnd += offset
+
+  const startValue = elementStart - viewportStart
+  const endValue = elementEnd - viewportEnd
+
+  const handleProgress = useEffectEvent(
+    (progress: number, lastProgress: number) => {
+      const direction: 1 | -1 = progress >= lastProgress ? 1 : -1
+      const clampedProgress = clamp(0, progress, 1)
+      const isActive = progress >= 0 && progress <= 1
+
+      onProgress?.({
+        height: endValue - startValue,
+        isActive,
+        progress: clampedProgress,
+        lastProgress,
+        direction,
+        steps: Array.from({ length: steps }).map((_, i) =>
+          clamp(0, mapRange(i / steps, (i + 1) / steps, progress, 0, 1), 1)
+        ),
+      })
+
+      if (debugRef.current) {
+        const { translate } = getTransform()
+        scrollTriggerStore.update(debugId, {
+          progress: clampedProgress,
+          isActive,
+          startPx: startValue,
+          endPx: endValue,
+          rect: {
+            top: rect?.top || 0,
+            left: rect?.left || 0,
+            width: rect?.width || 0,
+            height: rect?.height || 0,
+          },
+          translateY: translate.y,
+        })
+      }
+    }
+  )
+
+  const handleEnter = useEffectEvent(
+    (progress: number, lastProgress: number) => {
+      const direction: 1 | -1 = progress >= lastProgress ? 1 : -1
+      onEnter?.({ progress: clamp(0, progress, 1), direction })
+    }
+  )
+
+  const handleLeave = useEffectEvent(
+    (progress: number, lastProgress: number) => {
+      const direction: 1 | -1 = progress >= lastProgress ? 1 : -1
+      onLeave?.({ progress: clamp(0, progress, 1), direction })
+    }
+  )
+
+  const [setProgress] = useLazyState<number>(
+    Number.NaN,
+    (progress: number, lastProgress: number | undefined) => {
+      if (Number.isNaN(progress) || progress === undefined) return
+      if (lastProgress === undefined) return
+
+      if (
+        (progress >= 0 && lastProgress < 0) ||
+        (progress <= 1 && lastProgress > 1)
+      ) {
+        handleEnter(progress, lastProgress)
+      }
+
+      if (!(clamp(0, progress, 1) === clamp(0, lastProgress, 1))) {
+        handleProgress(progress, lastProgress)
+      }
+
+      if (
+        (progress < 0 && lastProgress >= 0) ||
+        (progress > 1 && lastProgress <= 1)
+      ) {
+        handleLeave(progress, lastProgress)
+      }
+    },
+    [endValue, startValue, steps]
+  )
+
+  const update = useEffectEvent(() => {
+    if (disabled) return
+    if (!isReady) return
+
+    const scroll = lenis ? Math.floor(lenis.scroll) : window.scrollY
+    const { translate } = getTransform()
+
+    // support for Lenis infinite scroll
+    const progress = mapRange(
+      0,
+      endValue - startValue,
+      modulo(scroll - translate.y - startValue, lenis?.limit ?? 0),
+      0,
+      1
+    )
+
+    setProgress(progress)
+  })
+
+  useEffect(() => {
+    if (lenis) {
+      lenis.on('scroll', update)
+      return () => {
+        lenis.off('scroll', update)
+      }
+    }
+
+    // Fallback to native scroll
+    update()
+    window.addEventListener('scroll', update, false)
+
+    return () => {
+      window.removeEventListener('scroll', update, false)
+    }
+  }, [lenis, update, ...deps])
+
+  // Recalculate when parent transforms change
+  useTransform(update)
+
+  // Run update when deps change
+  useEffect(update, [...deps])
+
+  // Debug: register/unregister from store
+  useEffect(() => {
+    if (!debug) return
+
+    scrollTriggerStore.register(debugId, {
+      id: debugId,
+      start,
+      end,
+      startPx: startValue,
+      endPx: endValue,
+      progress: 0,
+      isActive: false,
+      rect: {
+        top: rect?.top || 0,
+        left: rect?.left || 0,
+        width: rect?.width || 0,
+        height: rect?.height || 0,
+      },
+      translateY: 0,
+    })
+
+    return () => {
+      scrollTriggerStore.unregister(debugId)
+    }
+  }, [debug, debugId])
+
+  // Debug: sync store when rect/positions change
+  useEffect(() => {
+    if (!debug) return
+
+    scrollTriggerStore.update(debugId, {
+      start,
+      end,
+      startPx: startValue,
+      endPx: endValue,
+      rect: {
+        top: rect?.top || 0,
+        left: rect?.left || 0,
+        width: rect?.width || 0,
+        height: rect?.height || 0,
+      },
+    })
+  }, [
+    debug,
+    debugId,
+    start,
+    end,
+    startValue,
+    endValue,
+    rect?.top,
+    rect?.left,
+    rect?.width,
+    rect?.height,
+  ])
+
+  return [setRectRef, rect] as const
+}

--- a/packages/hamo/src/use-scroll-trigger/store.ts
+++ b/packages/hamo/src/use-scroll-trigger/store.ts
@@ -1,0 +1,60 @@
+// A tiny synchronous pub/sub used only by the debug overlay. Inlined (instead
+// of nanoevents) to keep hamo free of runtime dependencies.
+
+export interface TriggerEntry {
+  id: string
+  start: string
+  end: string
+  startPx: number
+  endPx: number
+  progress: number
+  isActive: boolean
+  rect: { top: number; left: number; width: number; height: number }
+  translateY: number
+}
+
+const subscribers = new Set<() => void>()
+const triggers = new Map<string, TriggerEntry>()
+let snapshot: TriggerEntry[] = []
+
+function updateSnapshot() {
+  snapshot = Array.from(triggers.values())
+}
+
+function emit() {
+  for (const callback of subscribers) callback()
+}
+
+export const scrollTriggerStore = {
+  register(id: string, entry: TriggerEntry) {
+    triggers.set(id, entry)
+    updateSnapshot()
+    emit()
+  },
+
+  update(id: string, partial: Partial<TriggerEntry>) {
+    const existing = triggers.get(id)
+    if (existing) {
+      Object.assign(existing, partial)
+      updateSnapshot()
+      emit()
+    }
+  },
+
+  unregister(id: string) {
+    triggers.delete(id)
+    updateSnapshot()
+    emit()
+  },
+
+  getSnapshot(): TriggerEntry[] {
+    return snapshot
+  },
+
+  subscribe(callback: () => void) {
+    subscribers.add(callback)
+    return () => {
+      subscribers.delete(callback)
+    }
+  },
+}

--- a/packages/hamo/src/use-transform/README.md
+++ b/packages/hamo/src/use-transform/README.md
@@ -1,0 +1,135 @@
+# useTransform
+
+A context-based transform accumulation system. `TransformProvider` tracks programmatic transforms (translate, rotate, scale) and propagates them down the component tree. `useTransform` lets child components read the accumulated transform or react to changes.
+
+The primary use case is **scroll trigger compensation** — when a parent element is translated programmatically (e.g., parallax), child `useScrollTrigger` hooks need to know about that offset to compute accurate progress values.
+
+## Usage
+
+```jsx
+import { useRef } from 'react'
+import { TransformProvider, useTransform } from 'hamo'
+import type { TransformRef } from 'hamo'
+
+function ParallaxSection() {
+  const transformRef = useRef<TransformRef>(null)
+
+  // Set transforms imperatively (e.g., from a scroll callback)
+  function onScroll(y) {
+    transformRef.current?.setTranslate(0, y)
+  }
+
+  return (
+    <TransformProvider ref={transformRef}>
+      <ChildComponent />
+    </TransformProvider>
+  )
+}
+
+function ChildComponent() {
+  // Read accumulated transform from all parent providers
+  const getTransform = useTransform()
+  const { translate } = getTransform()
+  // translate.y reflects the parent's offset
+
+  // Or react to changes:
+  useTransform((transform) => {
+    console.log('Parent moved to:', transform.translate.y)
+  })
+
+  return <div>Content</div>
+}
+```
+
+## TransformProvider
+
+Wraps a subtree with a transform context. Nested providers accumulate transforms:
+- **Translate** and **rotate**: additive
+- **Scale**: multiplicative
+
+### Props
+
+- `children`: (ReactNode) Child components.
+- `ref`: (Ref\<TransformRef\>) Optional imperative handle.
+
+### TransformRef Methods
+
+- `setTranslate(x?, y?, z?)` — Set translation (defaults: 0).
+- `setRotate(x?, y?, z?)` — Set rotation in degrees (defaults: 0).
+- `setScale(x?, y?, z?)` — Set scale (defaults: 1).
+
+## useTransform
+
+### Without callback
+
+Returns a `getTransform()` function to read the current accumulated transform on demand.
+
+```jsx
+const getTransform = useTransform()
+const { translate, rotate, scale } = getTransform()
+```
+
+### With callback
+
+Registers a callback that fires whenever any ancestor `TransformProvider` updates its transform.
+
+```jsx
+useTransform((transform) => {
+  element.style.transform = `translateY(${transform.translate.y}px)`
+})
+```
+
+### Parameters
+
+- `callback`: (function, optional) Fired with the accumulated `Transform` on every change.
+- `deps`: (array, default: `[]`) Dependencies for the callback effect.
+
+### Return Value
+
+Returns `getTransform` — a function that returns the current accumulated `Transform`.
+
+## Transform Type
+
+```ts
+type Transform = {
+  translate: { x: number; y: number; z: number }
+  rotate: { x: number; y: number; z: number }
+  scale: { x: number; y: number; z: number }
+}
+```
+
+## Example: Nested Providers
+
+```jsx
+import { useRef } from 'react'
+import { TransformProvider, useTransform } from 'hamo'
+import type { TransformRef } from 'hamo'
+
+function Outer() {
+  const ref = useRef<TransformRef>(null)
+  ref.current?.setTranslate(0, 100) // y = 100
+
+  return (
+    <TransformProvider ref={ref}>
+      <Inner />
+    </TransformProvider>
+  )
+}
+
+function Inner() {
+  const ref = useRef<TransformRef>(null)
+  ref.current?.setTranslate(0, 50) // y = 50
+
+  return (
+    <TransformProvider ref={ref}>
+      <Leaf />
+    </TransformProvider>
+  )
+}
+
+function Leaf() {
+  const getTransform = useTransform()
+  const { translate } = getTransform()
+  // translate.y === 150 (100 + 50, accumulated from both parents)
+}
+```

--- a/packages/hamo/src/use-transform/index.tsx
+++ b/packages/hamo/src/use-transform/index.tsx
@@ -1,0 +1,228 @@
+'use client'
+
+import {
+  createContext,
+  forwardRef,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from 'react'
+import { useEffectEvent } from '../use-effect-event'
+
+const DEFAULT_TRANSFORM = {
+  translate: { x: 0, y: 0, z: 0 },
+  rotate: { x: 0, y: 0, z: 0 },
+  scale: { x: 1, y: 1, z: 1 },
+  userData: {} as Record<string, unknown>,
+}
+
+export type Transform = typeof DEFAULT_TRANSFORM
+type TransformCallback = (transform: Transform) => void
+
+export type TransformRef = {
+  setTranslate: (x?: number, y?: number, z?: number) => void
+  setRotate: (x?: number, y?: number, z?: number) => void
+  setScale: (x?: number, y?: number, z?: number) => void
+  setUserData: (data: Record<string, unknown>) => void
+}
+
+type TransformContextType = {
+  getTransform: () => Transform
+  addCallback: (callback: TransformCallback) => void
+  removeCallback: (callback: TransformCallback) => void
+  setTranslate: (x?: number, y?: number, z?: number) => void
+  setRotate: (x?: number, y?: number, z?: number) => void
+  setScale: (x?: number, y?: number, z?: number) => void
+  setUserData: (data: Record<string, unknown>) => void
+}
+
+export const TransformContext = createContext<TransformContextType>({
+  getTransform: () => structuredClone(DEFAULT_TRANSFORM),
+  addCallback: () => {},
+  removeCallback: () => {},
+  setTranslate: () => {},
+  setRotate: () => {},
+  setScale: () => {},
+  setUserData: () => {},
+})
+
+type TransformProviderProps = {
+  children: ReactNode
+}
+
+/**
+ * Provider for managing element transforms in a composable hierarchy.
+ *
+ * Nested providers accumulate transforms — translate and rotate are additive,
+ * scale is multiplicative. This lets child components account for parent
+ * transforms (e.g., parallax offsets) when computing scroll positions.
+ *
+ * @example
+ * ```tsx
+ * import { TransformProvider, useTransform } from 'hamo'
+ *
+ * function ParallaxWrapper({ children }) {
+ *   const ref = useRef<TransformRef>(null)
+ *
+ *   // Update transform on scroll
+ *   useScrollTrigger({
+ *     onProgress: ({ progress }) => {
+ *       ref.current?.setTranslate(0, progress * -100)
+ *     },
+ *   })
+ *
+ *   return (
+ *     <TransformProvider ref={ref}>
+ *       {children}
+ *     </TransformProvider>
+ *   )
+ * }
+ * ```
+ */
+export const TransformProvider = forwardRef<
+  TransformRef,
+  TransformProviderProps
+>(function TransformProvider({ children }, ref) {
+  const parentTransformRef = useRef(structuredClone(DEFAULT_TRANSFORM))
+  const transformRef = useRef(structuredClone(DEFAULT_TRANSFORM))
+
+  function getTransform(): Transform {
+    const transform = structuredClone(parentTransformRef.current)
+
+    transform.translate.x += transformRef.current.translate.x
+    transform.translate.y += transformRef.current.translate.y
+    transform.translate.z += transformRef.current.translate.z
+
+    transform.rotate.x += transformRef.current.rotate.x
+    transform.rotate.y += transformRef.current.rotate.y
+    transform.rotate.z += transformRef.current.rotate.z
+
+    transform.scale.x *= transformRef.current.scale.x
+    transform.scale.y *= transformRef.current.scale.y
+    transform.scale.z *= transformRef.current.scale.z
+
+    transform.userData = {
+      ...transform.userData,
+      ...transformRef.current.userData,
+    }
+
+    return transform
+  }
+
+  const callbacksRef = useRef<TransformCallback[]>([])
+
+  const addCallback = useEffectEvent((callback: TransformCallback) => {
+    callbacksRef.current.push(callback)
+  })
+
+  const removeCallback = useEffectEvent((callback: TransformCallback) => {
+    callbacksRef.current = callbacksRef.current.filter((c) => c !== callback)
+  })
+
+  const update = useEffectEvent(() => {
+    const transform = getTransform()
+    for (const callback of callbacksRef.current) {
+      callback(transform)
+    }
+  })
+
+  function setTranslate(x = 0, y = 0, z = 0) {
+    if (!Number.isNaN(x)) transformRef.current.translate.x = Number(x)
+    if (!Number.isNaN(y)) transformRef.current.translate.y = Number(y)
+    if (!Number.isNaN(z)) transformRef.current.translate.z = Number(z)
+
+    update()
+  }
+
+  function setRotate(x = 0, y = 0, z = 0) {
+    if (!Number.isNaN(x)) transformRef.current.rotate.x = Number(x)
+    if (!Number.isNaN(y)) transformRef.current.rotate.y = Number(y)
+    if (!Number.isNaN(z)) transformRef.current.rotate.z = Number(z)
+    update()
+  }
+
+  function setScale(x = 1, y = 1, z = 1) {
+    if (!Number.isNaN(x)) transformRef.current.scale.x = Number(x)
+    if (!Number.isNaN(y)) transformRef.current.scale.y = Number(y)
+    if (!Number.isNaN(z)) transformRef.current.scale.z = Number(z)
+    update()
+  }
+
+  function setUserData(data: Record<string, unknown>) {
+    Object.assign(transformRef.current.userData, data)
+    update()
+  }
+
+  // Inherit parent transforms
+  useTransform((transform) => {
+    parentTransformRef.current = structuredClone(transform)
+    update()
+  })
+
+  useImperativeHandle(ref, () => ({
+    setTranslate,
+    setRotate,
+    setScale,
+    setUserData,
+  }))
+
+  return (
+    <TransformContext.Provider
+      value={{
+        getTransform,
+        addCallback,
+        removeCallback,
+        setTranslate,
+        setRotate,
+        setScale,
+        setUserData,
+      }}
+    >
+      {children}
+    </TransformContext.Provider>
+  )
+})
+
+/**
+ * Hook to access and react to transform changes from TransformProvider.
+ *
+ * Without a callback, returns a `getTransform()` function to read the current
+ * accumulated transform. With a callback, it fires whenever any ancestor
+ * TransformProvider updates its transform.
+ *
+ * @param callback - Optional callback fired on transform changes
+ * @param deps - Dependencies for the callback effect
+ * @returns Function to get current accumulated transform
+ *
+ * @example
+ * ```tsx
+ * // Read transform on demand
+ * const getTransform = useTransform()
+ * const { translate } = getTransform()
+ *
+ * // React to transform changes
+ * useTransform((transform) => {
+ *   element.style.transform = `translateY(${transform.translate.y}px)`
+ * })
+ * ```
+ */
+export function useTransform(
+  callback?: TransformCallback,
+  deps = [] as unknown[]
+) {
+  const { getTransform, addCallback, removeCallback } =
+    useContext(TransformContext)
+
+  useEffect(() => {
+    if (!callback) return
+
+    addCallback(callback)
+    return () => {
+      removeCallback(callback)
+    }
+  }, [callback, addCallback, removeCallback, ...deps])
+
+  return getTransform
+}

--- a/packages/hamo/tsdown.config.ts
+++ b/packages/hamo/tsdown.config.ts
@@ -5,11 +5,17 @@ import { defineConfig } from 'tsdown'
 // output. `unbundle` preserves the per-file `"use client"` directives so the pure
 // utilities (useObjectFit) stay usable in Server Components.
 export default defineConfig({
-  entry: { hamo: 'src/index.ts' },
+  entry: {
+    hamo: 'src/index.ts',
+    'use-scroll-trigger/debugger': 'src/use-scroll-trigger/debugger.tsx',
+  },
   outDir: 'dist',
   target: 'es2022',
   platform: 'neutral',
   format: ['esm', 'cjs'],
+  // lenis is an optional peer (useScrollTrigger falls back to native scroll);
+  // never bundle it.
+  external: [/^lenis(\/|$)/],
   unbundle: true,
   dts: true,
   sourcemap: true,

--- a/playground/react/scroll-trigger-app.tsx
+++ b/playground/react/scroll-trigger-app.tsx
@@ -1,0 +1,730 @@
+import { useScrollTrigger, TransformProvider, useRect } from 'hamo'
+import { Debugger } from 'hamo/scroll-trigger/debugger'
+import type { TransformRef, UseScrollTriggerOptions } from 'hamo'
+import { useRef, useState } from 'react'
+
+function Section({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className="st-section">
+      <h2>{title}</h2>
+      <div className="st-section-content">{children}</div>
+    </section>
+  )
+}
+
+function Value({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="st-value">
+      <span className="st-value-label">{label}</span>
+      <span className="st-value-data">{value ?? '---'}</span>
+    </div>
+  )
+}
+
+// 1. Hero / Intro
+function HeroSection() {
+  return (
+    <Section title="useScrollTrigger">
+      <p className="st-description">
+        Scroll-based progress tracking with GSAP ScrollTrigger-like position
+        syntax. Integrates with Lenis when available, falls back to native
+        scroll events. Scroll down to explore each feature.
+      </p>
+      <p className="st-description">
+        <strong>Position syntax:</strong>{' '}
+        <code>"element-position viewport-position"</code>
+      </p>
+      <table className="st-syntax-table">
+        <thead>
+          <tr>
+            <th>Position</th>
+            <th>Element</th>
+            <th>Viewport</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>top</td>
+            <td>Top edge of element</td>
+            <td>Top of viewport</td>
+          </tr>
+          <tr>
+            <td>center</td>
+            <td>Center of element</td>
+            <td>Center of viewport</td>
+          </tr>
+          <tr>
+            <td>bottom</td>
+            <td>Bottom edge of element</td>
+            <td>Bottom of viewport</td>
+          </tr>
+          <tr>
+            <td>number</td>
+            <td>Pixel offset from top</td>
+            <td>Pixel offset from top</td>
+          </tr>
+        </tbody>
+      </table>
+    </Section>
+  )
+}
+
+// 2. Basic Progress
+function BasicProgressDemo() {
+  const progressBarRef = useRef<HTMLDivElement>(null)
+  const boxRef = useRef<HTMLDivElement>(null)
+  const progressValueRef = useRef<HTMLSpanElement>(null)
+  const activeValueRef = useRef<HTMLSpanElement>(null)
+  const heightValueRef = useRef<HTMLSpanElement>(null)
+  const directionValueRef = useRef<HTMLSpanElement>(null)
+
+  const [setRef] = useScrollTrigger({
+    start: 'bottom bottom',
+    end: 'top top',
+    debug: 'basic',
+    onEnter: () => {
+      if (boxRef.current) boxRef.current.dataset.active = 'true'
+    },
+    onLeave: () => {
+      if (boxRef.current) boxRef.current.dataset.active = 'false'
+    },
+    onProgress: ({ progress, isActive, height, direction }) => {
+      if (progressBarRef.current) {
+        progressBarRef.current.style.transform = `scaleX(${progress})`
+      }
+      if (progressValueRef.current) {
+        progressValueRef.current.textContent = progress.toFixed(3)
+      }
+      if (activeValueRef.current) {
+        activeValueRef.current.textContent = isActive ? 'true' : 'false'
+      }
+      if (heightValueRef.current) {
+        heightValueRef.current.textContent = `${Math.round(height)}px`
+      }
+      if (directionValueRef.current) {
+        directionValueRef.current.textContent =
+          direction === 1 ? '\u2193 down' : '\u2191 up'
+      }
+    },
+  })
+
+  return (
+    <Section title="Basic Progress">
+      <p className="st-description">
+        Tracks scroll progress from 0 to 1 as the element traverses the
+        viewport. Uses <code>start: "bottom bottom"</code> and{' '}
+        <code>end: "top top"</code> (the defaults) for full traversal.
+      </p>
+      <div className="st-spacer">
+        <span>Scroll to see progress</span>
+      </div>
+      <div
+        ref={(el) => {
+          setRef(el)
+          boxRef.current = el
+        }}
+        className="st-progress-box"
+        data-active="false"
+      >
+        <div className="st-progress-bar" ref={progressBarRef} />
+        <div className="st-progress-info">
+          <Value
+            label="progress"
+            value={<span ref={progressValueRef}>0.000</span>}
+          />
+          <Value
+            label="isActive"
+            value={<span ref={activeValueRef}>false</span>}
+          />
+          <Value label="height" value={<span ref={heightValueRef}>---</span>} />
+          <Value
+            label="direction"
+            value={<span ref={directionValueRef}>---</span>}
+          />
+        </div>
+        <p className="st-hint">start: "bottom bottom" / end: "top top"</p>
+      </div>
+      <div className="st-spacer">
+        <span>Scroll back up</span>
+      </div>
+    </Section>
+  )
+}
+
+// 3. Enter / Leave Events
+function EnterLeaveDemo() {
+  const boxRef = useRef<HTMLDivElement>(null)
+  const logRef = useRef<HTMLDivElement>(null)
+  const eventsRef = useRef<string[]>([])
+
+  const addEvent = (
+    type: 'enter' | 'leave',
+    progress: number,
+    direction: 1 | -1
+  ) => {
+    const time = new Date().toLocaleTimeString('en-US', {
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+    const className = type === 'enter' ? 'st-event-enter' : 'st-event-leave'
+    const label = type === 'enter' ? 'ENTER' : 'LEAVE'
+    const dir = direction === 1 ? '\u2193' : '\u2191'
+    eventsRef.current = [
+      ...eventsRef.current.slice(-4),
+      `<span class="${className}">[${time}] ${label} ${dir}</span> progress: ${progress.toFixed(3)}`,
+    ]
+    if (logRef.current) {
+      logRef.current.innerHTML = eventsRef.current.join('<br/>')
+    }
+  }
+
+  const [setRef] = useScrollTrigger({
+    start: 'bottom bottom',
+    end: 'top top',
+    debug: 'events',
+    onEnter: ({ progress, direction }) => {
+      if (boxRef.current) boxRef.current.dataset.active = 'true'
+      addEvent('enter', progress, direction)
+    },
+    onLeave: ({ progress, direction }) => {
+      if (boxRef.current) boxRef.current.dataset.active = 'false'
+      addEvent('leave', progress, direction)
+    },
+  })
+
+  return (
+    <Section title="Enter / Leave Events">
+      <p className="st-description">
+        <code>onEnter</code> fires when the element enters the trigger zone.{' '}
+        <code>onLeave</code> fires when it exits. Each callback receives{' '}
+        <code>direction</code> (1 = down, -1 = up). Scroll past this element and
+        back to see the event log update.
+      </p>
+      <div className="st-spacer">
+        <span>Scroll to trigger enter/leave</span>
+      </div>
+      <div
+        ref={(el) => {
+          setRef(el)
+          boxRef.current = el
+        }}
+        className="st-event-box"
+        data-active="false"
+      >
+        <Value label="status" value="Scroll through to trigger events" />
+        <div className="st-event-log" ref={logRef}>
+          Waiting for events...
+        </div>
+      </div>
+      <div className="st-spacer">
+        <span>Scroll back up</span>
+      </div>
+    </Section>
+  )
+}
+
+// 4. Position Combinations
+function PositionCard({
+  startPos,
+  endPos,
+  label,
+}: {
+  startPos: string
+  endPos: string
+  label: string
+}) {
+  const progressBarRef = useRef<HTMLDivElement>(null)
+  const cardRef = useRef<HTMLDivElement>(null)
+  const valueRef = useRef<HTMLSpanElement>(null)
+
+  const [setRef] = useScrollTrigger({
+    start: startPos as UseScrollTriggerOptions['start'],
+    end: endPos as UseScrollTriggerOptions['end'],
+    debug: label,
+    onEnter: () => {
+      if (cardRef.current) cardRef.current.dataset.active = 'true'
+    },
+    onLeave: () => {
+      if (cardRef.current) cardRef.current.dataset.active = 'false'
+    },
+    onProgress: ({ progress }) => {
+      if (progressBarRef.current) {
+        progressBarRef.current.style.transform = `scaleX(${progress})`
+      }
+      if (valueRef.current) {
+        valueRef.current.textContent = progress.toFixed(3)
+      }
+    },
+  })
+
+  return (
+    <div
+      ref={(el) => {
+        setRef(el)
+        cardRef.current = el
+      }}
+      className="st-position-card"
+      data-active="false"
+    >
+      <div className="st-progress-bar" ref={progressBarRef} />
+      <div className="st-position-label">{label}</div>
+      <div className="st-position-label">
+        start: "{startPos}" / end: "{endPos}"
+      </div>
+      <div className="st-position-value">
+        <span ref={valueRef}>0.000</span>
+      </div>
+    </div>
+  )
+}
+
+function PositionCombinationsDemo() {
+  return (
+    <Section title="Position Combinations">
+      <p className="st-description">
+        Different <code>start</code> / <code>end</code> positions change when
+        progress runs. Compare how each configuration behaves as you scroll.
+      </p>
+      <div className="st-spacer">
+        <span>Scroll to compare positions</span>
+      </div>
+      <div className="st-positions-grid">
+        <PositionCard
+          startPos="bottom bottom"
+          endPos="top top"
+          label="Full traversal (default)"
+        />
+        <PositionCard
+          startPos="bottom bottom"
+          endPos="top center"
+          label="Bottom to center"
+        />
+        <PositionCard
+          startPos="center center"
+          endPos="top top"
+          label="Center to top"
+        />
+      </div>
+      <div className="st-spacer">
+        <span>Scroll back up</span>
+      </div>
+    </Section>
+  )
+}
+
+// 5. Steps / Staggered Animation
+function StepsDemo() {
+  const itemRefs = useRef<(HTMLDivElement | null)[]>([])
+  const STEP_COUNT = 6
+
+  const [setRef] = useScrollTrigger({
+    start: 'bottom bottom',
+    end: 'top top',
+    steps: STEP_COUNT,
+    debug: 'steps',
+    onProgress: ({ steps }) => {
+      for (let i = 0; i < steps.length; i++) {
+        const el = itemRefs.current[i]
+        if (el) {
+          const stepProgress = steps[i]
+          el.style.opacity = String(0.2 + stepProgress * 0.8)
+          el.style.transform = `translateY(${(1 - stepProgress) * 20}px)`
+          el.dataset.visible = stepProgress > 0 ? 'true' : 'false'
+        }
+      }
+    },
+  })
+
+  return (
+    <Section title="Steps / Staggered Animation">
+      <p className="st-description">
+        Using <code>steps: {STEP_COUNT}</code> to subdivide progress into{' '}
+        {STEP_COUNT} discrete sub-ranges. Each item animates based on its
+        individual step progress, creating a staggered effect.
+      </p>
+      <div className="st-spacer">
+        <span>Scroll to see staggered animation</span>
+      </div>
+      <div ref={setRef} className="st-steps-list">
+        {Array.from({ length: STEP_COUNT }).map((_, i) => (
+          <div
+            key={i}
+            ref={(el) => {
+              itemRefs.current[i] = el
+            }}
+            className="st-step-item"
+            data-visible="false"
+          >
+            Step {i + 1} / {STEP_COUNT}
+          </div>
+        ))}
+      </div>
+      <div className="st-spacer">
+        <span>Scroll back up</span>
+      </div>
+    </Section>
+  )
+}
+
+// 6. Offset
+function OffsetDemo() {
+  const cardARef = useRef<HTMLDivElement>(null)
+  const cardBRef = useRef<HTMLDivElement>(null)
+  const valueARef = useRef<HTMLSpanElement>(null)
+  const valueBRef = useRef<HTMLSpanElement>(null)
+
+  const [setRefA] = useScrollTrigger({
+    start: 'bottom bottom',
+    end: 'top top',
+    offset: 0,
+    debug: 'offset-0',
+    onEnter: () => {
+      if (cardARef.current) cardARef.current.dataset.active = 'true'
+    },
+    onLeave: () => {
+      if (cardARef.current) cardARef.current.dataset.active = 'false'
+    },
+    onProgress: ({ progress }) => {
+      if (valueARef.current) {
+        valueARef.current.textContent = progress.toFixed(3)
+      }
+    },
+  })
+
+  const [setRefB] = useScrollTrigger({
+    start: 'bottom bottom',
+    end: 'top top',
+    offset: -200,
+    debug: 'offset-200',
+    onEnter: () => {
+      if (cardBRef.current) cardBRef.current.dataset.active = 'true'
+    },
+    onLeave: () => {
+      if (cardBRef.current) cardBRef.current.dataset.active = 'false'
+    },
+    onProgress: ({ progress }) => {
+      if (valueBRef.current) {
+        valueBRef.current.textContent = progress.toFixed(3)
+      }
+    },
+  })
+
+  return (
+    <Section title="Offset">
+      <p className="st-description">
+        The <code>offset</code> option shifts element positions by a pixel
+        amount. Compare <code>offset: 0</code> (default) vs{' '}
+        <code>offset: -200</code> - the second triggers earlier.
+      </p>
+      <div className="st-spacer">
+        <span>Scroll to compare offsets</span>
+      </div>
+      <div className="st-offset-grid">
+        <div
+          ref={(el) => {
+            setRefA(el)
+            cardARef.current = el
+          }}
+          className="st-offset-card"
+          data-active="false"
+        >
+          <div className="st-offset-label">offset: 0</div>
+          <div className="st-offset-value">
+            <span ref={valueARef}>0.000</span>
+          </div>
+        </div>
+        <div
+          ref={(el) => {
+            setRefB(el)
+            cardBRef.current = el
+          }}
+          className="st-offset-card"
+          data-active="false"
+        >
+          <div className="st-offset-label">offset: -200</div>
+          <div className="st-offset-value">
+            <span ref={valueBRef}>0.000</span>
+          </div>
+        </div>
+      </div>
+      <div className="st-spacer">
+        <span>Scroll back up</span>
+      </div>
+    </Section>
+  )
+}
+
+// 7. Disabled Toggle
+function DisabledDemo() {
+  const [disabled, setDisabled] = useState(false)
+  const progressBarRef = useRef<HTMLDivElement>(null)
+  const boxRef = useRef<HTMLDivElement>(null)
+  const valueRef = useRef<HTMLSpanElement>(null)
+
+  const [setRef] = useScrollTrigger({
+    start: 'bottom bottom',
+    end: 'top top',
+    disabled,
+    debug: 'disabled',
+    onEnter: () => {
+      if (boxRef.current) boxRef.current.dataset.active = 'true'
+    },
+    onLeave: () => {
+      if (boxRef.current) boxRef.current.dataset.active = 'false'
+    },
+    onProgress: ({ progress }) => {
+      if (progressBarRef.current) {
+        progressBarRef.current.style.transform = `scaleX(${progress})`
+      }
+      if (valueRef.current) {
+        valueRef.current.textContent = progress.toFixed(3)
+      }
+    },
+  })
+
+  return (
+    <Section title="Disabled Toggle">
+      <p className="st-description">
+        The <code>disabled</code> option stops progress updates. Toggle it to
+        see the progress bar freeze in place.
+      </p>
+      <div className="st-toggle-row">
+        <button
+          type="button"
+          data-active={String(disabled)}
+          onClick={() => setDisabled((v) => !v)}
+          aria-label={
+            disabled ? 'Enable scroll trigger' : 'Disable scroll trigger'
+          }
+        >
+          {disabled ? 'Disabled' : 'Enabled'}
+        </button>
+      </div>
+      <div className="st-spacer">
+        <span>Scroll to see progress {disabled ? '(disabled)' : ''}</span>
+      </div>
+      <div
+        ref={(el) => {
+          setRef(el)
+          boxRef.current = el
+        }}
+        className="st-progress-box"
+        data-active="false"
+      >
+        <div className="st-progress-bar" ref={progressBarRef} />
+        <div className="st-progress-info">
+          <Value label="progress" value={<span ref={valueRef}>0.000</span>} />
+          <Value label="disabled" value={disabled ? 'true' : 'false'} />
+        </div>
+      </div>
+      <div className="st-spacer">
+        <span>Scroll back up</span>
+      </div>
+    </Section>
+  )
+}
+
+// 8. CSS Custom Property
+function CSSPropertyDemo() {
+  const boxRef = useRef<HTMLDivElement>(null)
+  const valueRef = useRef<HTMLSpanElement>(null)
+
+  const [setRef] = useScrollTrigger({
+    start: 'bottom bottom',
+    end: 'top top',
+    debug: 'css-prop',
+    onProgress: ({ progress }) => {
+      if (boxRef.current) {
+        boxRef.current.style.setProperty('--progress', String(progress))
+      }
+      if (valueRef.current) {
+        valueRef.current.textContent = progress.toFixed(3)
+      }
+    },
+  })
+
+  return (
+    <Section title="CSS Custom Property">
+      <p className="st-description">
+        Set <code>--progress</code> as a CSS custom property to drive transforms
+        purely through CSS. The box below uses <code>translateY</code>,{' '}
+        <code>scale</code>, <code>rotate</code>, and <code>opacity</code> all
+        driven by a single variable.
+      </p>
+      <div className="st-spacer">
+        <span>Scroll to animate via CSS variable</span>
+      </div>
+      <div
+        ref={(el) => {
+          setRef(el)
+          boxRef.current = el
+        }}
+        className="st-css-demo"
+      >
+        <div className="st-css-box" />
+        <span className="st-css-label">
+          --progress: <span ref={valueRef}>0.000</span>
+        </span>
+      </div>
+      <div className="st-spacer">
+        <span>Scroll back up</span>
+      </div>
+    </Section>
+  )
+}
+
+// 9. TransformProvider (Parallax Compensation)
+function TransformChildTrigger() {
+  const progressBarRef = useRef<HTMLDivElement>(null)
+  const valueRef = useRef<HTMLSpanElement>(null)
+  const boxRef = useRef<HTMLDivElement>(null)
+
+  const [setRectRef, rect] = useRect({
+    ignoreTransform: true,
+  })
+  useScrollTrigger({
+    rect,
+    debug: 'child',
+    onEnter: () => {
+      if (boxRef.current) boxRef.current.dataset.active = 'true'
+    },
+    onLeave: () => {
+      if (boxRef.current) boxRef.current.dataset.active = 'false'
+    },
+    onProgress: ({ progress }) => {
+      if (progressBarRef.current) {
+        progressBarRef.current.style.transform = `scaleX(${progress})`
+      }
+      if (valueRef.current) {
+        valueRef.current.textContent = progress.toFixed(3)
+      }
+    },
+  })
+
+  return (
+    <div
+      ref={(el) => {
+        setRectRef(el)
+        boxRef.current = el
+      }}
+      className="st-transform-child"
+      data-active="false"
+    >
+      <div className="st-progress-bar" ref={progressBarRef} />
+      <Value label="child progress" value={<span ref={valueRef}>0.000</span>} />
+      <p className="st-hint">
+        This child compensates for the parent's translateY
+      </p>
+    </div>
+  )
+}
+
+function TransformDemo() {
+  const transformRef = useRef<TransformRef>(null)
+  const parentRef = useRef<HTMLDivElement>(null)
+  const offsetValueRef = useRef<HTMLSpanElement>(null)
+
+  const [setRef] = useScrollTrigger({
+    start: 'bottom bottom',
+    end: 'top top',
+    debug: 'parallax',
+    onProgress: ({ progress }) => {
+      const y = (progress - 0.5) * -400
+      transformRef.current?.setTranslate(0, y)
+      if (parentRef.current) {
+        parentRef.current.style.transform = `translateY(${y}px)`
+      }
+      if (offsetValueRef.current) {
+        offsetValueRef.current.textContent = `${Math.round(y)}px`
+      }
+    },
+  })
+
+  return (
+    <Section title="TransformProvider">
+      <p className="st-description">
+        When a parent element is translated programmatically (e.g., parallax),
+        child <code>useScrollTrigger</code> hooks need to know about that
+        offset. <code>TransformProvider</code> propagates transform state down
+        the tree so child triggers compute accurate progress despite the parent
+        moving.
+      </p>
+      <div className="st-spacer">
+        <span>Scroll to see parallax compensation</span>
+      </div>
+      <TransformProvider ref={transformRef}>
+        <div
+          ref={(el) => {
+            setRef(el)
+            parentRef.current = el
+          }}
+          className="st-transform-parent"
+        >
+          <div className="st-transform-header">
+            <Value
+              label="parent translateY"
+              value={<span ref={offsetValueRef}>0px</span>}
+            />
+          </div>
+          <TransformChildTrigger />
+        </div>
+      </TransformProvider>
+      <div className="st-spacer">
+        <span>Scroll back up</span>
+      </div>
+    </Section>
+  )
+}
+
+export default function ScrollTriggerApp() {
+  return (
+    <div className="st-playground">
+      <Debugger theme="light" />
+      <header>
+        <h1>useScrollTrigger</h1>
+        <p>
+          Scroll-based progress tracking with position syntax, enter/leave
+          callbacks, steps, offset, and CSS variable integration.
+        </p>
+      </header>
+
+      <HeroSection />
+      <BasicProgressDemo />
+      <EnterLeaveDemo />
+      <PositionCombinationsDemo />
+      <StepsDemo />
+      <OffsetDemo />
+      <DisabledDemo />
+      <CSSPropertyDemo />
+      <TransformDemo />
+
+      <footer>
+        <p>
+          <a
+            href="https://github.com/darkroomengineering/hamo"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub
+          </a>
+          {' / '}
+          <a
+            href="https://www.npmjs.com/package/hamo"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            npm
+          </a>
+        </p>
+      </footer>
+    </div>
+  )
+}

--- a/playground/react/scroll-trigger-style.css
+++ b/playground/react/scroll-trigger-style.css
@@ -1,0 +1,434 @@
+body {
+  min-height: 100vh;
+}
+
+.st-playground {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 24px 100px;
+}
+
+.st-playground header {
+  padding: 40px 0;
+  text-align: center;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 40px;
+}
+
+.st-playground header h1 {
+  font-family: monospace;
+  font-size: 24px;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin: 0 0 8px;
+}
+
+.st-playground header p {
+  color: var(--color-muted);
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.st-section {
+  margin-bottom: 48px;
+  padding-bottom: 48px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.st-section h2 {
+  font-family: monospace;
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-accent);
+  margin: 0 0 12px;
+}
+
+.st-description {
+  font-size: 14px;
+  color: var(--color-muted);
+  margin: 0 0 20px;
+  line-height: 1.6;
+}
+
+.st-description code {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.st-hint {
+  font-size: 12px;
+  color: var(--color-accent);
+  margin: 12px 0 0;
+  font-style: italic;
+  font-family: monospace;
+}
+
+.st-section-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.st-values-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.st-value {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+}
+
+.st-value-label {
+  font-family: monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-muted);
+}
+
+.st-value-data {
+  font-family: monospace;
+  font-size: 18px;
+  font-weight: 500;
+}
+
+/* Spacer between sections */
+.st-spacer {
+  height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-muted);
+  font-family: monospace;
+  font-size: 12px;
+}
+
+/* Position syntax table */
+.st-syntax-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: monospace;
+  font-size: 13px;
+  margin-top: 8px;
+}
+
+.st-syntax-table th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-muted);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
+
+.st-syntax-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.st-syntax-table td:first-child {
+  color: var(--color-accent);
+}
+
+/* Progress box */
+.st-progress-box {
+  position: relative;
+  padding: 40px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 2px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+  transition: border-color 0.3s ease;
+}
+
+.st-progress-box[data-active="true"] {
+  border-color: var(--color-accent);
+}
+
+.st-progress-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--color-accent);
+  transform-origin: left;
+  transform: scaleX(0);
+}
+
+.st-progress-info {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+}
+
+/* Enter/Leave events */
+.st-event-box {
+  position: relative;
+  padding: 40px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 2px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+  transition: border-color 0.3s ease, background 0.3s ease;
+}
+
+.st-event-box[data-active="true"] {
+  border-color: var(--color-accent);
+  background: rgba(227, 6, 19, 0.08);
+}
+
+.st-event-log {
+  margin-top: 16px;
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 6px;
+  font-family: monospace;
+  font-size: 11px;
+  color: var(--color-muted);
+  min-height: 80px;
+  line-height: 1.8;
+}
+
+.st-event-log .st-event-enter {
+  color: #4ade80;
+}
+
+.st-event-log .st-event-leave {
+  color: #f87171;
+}
+
+/* Position combinations */
+.st-positions-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.st-position-card {
+  position: relative;
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 2px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+  transition: border-color 0.3s ease;
+}
+
+.st-position-card[data-active="true"] {
+  border-color: var(--color-accent);
+}
+
+.st-position-card .st-progress-bar {
+  height: 2px;
+}
+
+.st-position-label {
+  font-family: monospace;
+  font-size: 11px;
+  color: var(--color-muted);
+  margin-bottom: 8px;
+}
+
+.st-position-value {
+  font-family: monospace;
+  font-size: 24px;
+  font-weight: 500;
+}
+
+/* Steps / Staggered animation */
+.st-steps-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.st-step-item {
+  padding: 20px 24px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  font-family: monospace;
+  font-size: 14px;
+  opacity: 0.2;
+  transform: translateY(20px);
+  transition: border-color 0.2s ease;
+}
+
+.st-step-item[data-visible="true"] {
+  border-color: var(--color-accent);
+}
+
+/* Offset comparison */
+.st-offset-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.st-offset-card {
+  position: relative;
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 2px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+  transition: border-color 0.3s ease;
+}
+
+.st-offset-card[data-active="true"] {
+  border-color: var(--color-accent);
+}
+
+.st-offset-label {
+  font-family: monospace;
+  font-size: 11px;
+  color: var(--color-muted);
+  margin-bottom: 8px;
+}
+
+.st-offset-value {
+  font-family: monospace;
+  font-size: 24px;
+  font-weight: 500;
+}
+
+/* Disabled toggle */
+.st-toggle-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.st-toggle-row button {
+  font-family: monospace;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 10px 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg);
+  color: var(--color-fg);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.st-toggle-row button:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.st-toggle-row button:active {
+  transform: scale(0.98);
+}
+
+.st-toggle-row button[data-active="true"] {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: white;
+}
+
+/* CSS custom property demo */
+.st-css-demo {
+  position: relative;
+  height: 300px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 2px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.st-css-box {
+  width: 100px;
+  height: 100px;
+  background: var(--color-accent);
+  border-radius: 8px;
+  transform:
+    translateY(calc((1 - var(--progress, 0)) * 40px))
+    scale(calc(0.5 + var(--progress, 0) * 0.5))
+    rotate(calc(var(--progress, 0) * 180deg));
+  opacity: calc(0.2 + var(--progress, 0) * 0.8);
+  transition: none;
+}
+
+.st-css-label {
+  position: absolute;
+  bottom: 12px;
+  left: 12px;
+  font-family: monospace;
+  font-size: 11px;
+  color: var(--color-muted);
+}
+
+/* TransformProvider demo */
+.st-transform-parent {
+  position: relative;
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 2px dashed var(--color-border);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.st-transform-header {
+  display: flex;
+  gap: 12px;
+}
+
+.st-transform-child {
+  position: relative;
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 2px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+  transition: border-color 0.3s ease;
+}
+
+.st-transform-child[data-active="true"] {
+  border-color: var(--color-accent);
+}
+
+/* Footer */
+.st-playground footer {
+  padding: 40px 0;
+  text-align: center;
+}
+
+.st-playground footer p {
+  margin: 0;
+  font-family: monospace;
+  font-size: 12px;
+  color: var(--color-muted);
+}
+
+.st-playground footer a {
+  color: var(--color-fg);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.st-playground footer a:hover {
+  color: var(--color-accent);
+}

--- a/playground/www/layouts/Layout.astro
+++ b/playground/www/layouts/Layout.astro
@@ -22,6 +22,7 @@ const { title } = Astro.props
         </svg>
       </a>
       <a href="/react">React</a>
+      <a href="/scroll-trigger">ScrollTrigger</a>
     </nav>
     <main>
       <slot />

--- a/playground/www/pages/index.astro
+++ b/playground/www/pages/index.astro
@@ -30,6 +30,9 @@ import pkg from '../../../packages/hamo/package.json'
         <li><code>useDebouncedCallback</code> <span>Debounced callbacks</span></li>
         <li><code>useDebouncedEffect</code> <span>Debounced effects</span></li>
         <li><code>useObjectFit</code> <span>Contain/cover calculations</span></li>
+        <li><code>useScrollTrigger</code> <span>Scroll-based progress tracking</span></li>
+        <li><code>useTransform</code> <span>Nested transform accumulation</span></li>
+        <li><code>useEffectEvent</code> <span>Stable callback reference</span></li>
       </ul>
     </div>
   </div>

--- a/playground/www/pages/scroll-trigger.astro
+++ b/playground/www/pages/scroll-trigger.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '../layouts/Layout.astro'
+import pkg from '../../../package.json'
+import ScrollTriggerApp from '~/react/scroll-trigger-app'
+import '~/react/scroll-trigger-style.css'
+---
+
+<Layout title={`${pkg.name} + useScrollTrigger`}>
+  <ScrollTriggerApp client:only="react" />
+</Layout>


### PR DESCRIPTION
## What this does
Brings Clément Roche's scroll hooks (#11) into the v1 `packages/hamo` library: **useScrollTrigger** (scroll-progress tracking for scrollytelling), **useTransform / TransformProvider** (parallax), and a public **useEffectEvent**. They were stranded on a branch built against the old repo layout; this re-applies them to the restructured monorepo so they ship with v1.

## Summary
- `useEffectEvent` promoted to a public hook; `use-debounce` now consumes it (removes the private `useStableCallback` duplicate).
- `useTransform` / `TransformProvider` — zero-dep context transform accumulation for parallax.
- `useScrollTrigger` + `Debugger` — position syntax, optional Lenis integration with graceful native-scroll fallback; debug overlay behind the `hamo/scroll-trigger/debugger` subpath export.
- `lenis` is an **optional** peer dependency; the store emitter is inlined so hamo keeps **zero runtime dependencies**.
- Playground gains a `/scroll-trigger` demo.

## Test Plan
- [x] typecheck + lint + build clean
- [x] 46 unit tests pass
- [x] playground builds (`astro check` 0 errors, 3 pages)
- [x] published tarball: new hooks + debugger present, runtime deps still none, lenis externalized

Ports #11 — credit @clementroche (Co-Authored-By on the commit).