### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,29 +1,37 @@
 name: Publish to NPM
+
 on:
   release:
     types: [created]
+
+permissions:
+  contents: read
+  id-token: write # OIDC token for npm trusted publishing (no NPM_TOKEN needed)
+
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v3
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
-          registry-url: 'https://registry.npmjs.org'
+          node-version: 22
+          registry-url: https://registry.npmjs.org
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 7
-          run_install: false
+      # Trusted publishing needs npm >= 11.5; Node 22 ships npm 10.x.
+      - name: Upgrade npm for OIDC
+        run: npm install -g npm@latest
 
-      - name: Install dependencies and build
-        run: pnpm i --frozen-lockfile
-      - name: Publish package on NPM
+      - name: Install
+        run: bun install
+
+      # tsdown build — npm publish does not build on its own, and `files`
+      # only ships dist/, so this must run before publishing.
+      - name: Build
+        run: bun run build
+
+      - name: Publish to npm (OIDC trusted publishing)
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What this does

Switches hamo's npm publish from a long-lived `NPM_TOKEN` to **npm Trusted Publishing (OIDC)** — the same setup just rolled out on `fitbox`. GitHub Actions mints a short-lived OIDC token that npm trades for publish rights, so there's no secret to leak and no 2FA-for-writes wall (that's what was breaking token publishes org-wide).

It also **repairs the workflow**, which couldn't have been working: the old job ran `pnpm i --frozen-lockfile`, but hamo is a bun workspace with no pnpm lockfile, and it never built `dist/` (`npm publish` doesn't build, and `files` only ships `dist/`). So dev releases must have been hand-published.

## Summary
- `release: created` trigger unchanged.
- Auth: drop `NODE_AUTH_TOKEN: secrets.NPM_TOKEN`; add `id-token: write`; upgrade npm to an OIDC-capable version.
- Install/build: `bun install` + `bun run build` (tsdown) before publish. Node 16 → 22.

## One-time setup required before the next release
On npmjs.com, add a **Trusted Publisher** for the `hamo` package:
- Organization or user: `darkroomengineering`
- Repository: `hamo`
- Workflow filename: `publish.yml`
- Environment: (blank)

Until that's configured, publishing will 404 (npm won't recognize the publisher). Merging this PR does **not** publish anything — it only takes effect on the next GitHub Release.

## Test Plan
- [ ] Configure the Trusted Publisher (above)
- [ ] Cut a test/dev GitHub Release and confirm the run publishes with provenance
- [ ] Then delete the org-shared `NPM_TOKEN` once nothing else uses it