### PR TITLE
chore: weekly maintenance — dep bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   ],
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "tsdown": "^0.21.4",
+    "tsdown": "^0.22.13",
     "typescript": "^5.4.5"
   },
   "dependencies": {


### PR DESCRIPTION
Weekly automated dependency sweep.

## What was bumped
- `tsdown` `^0.21.4` → `^0.22.13` (dev dependency, root package)

That's the only change: `bun.lock` is gitignored in this repo, so every install already resolves to the newest version allowed by each declared semver range — there was nothing else left to bump within-range across any workspace (root, `playground`, `packages/react`). All other outdated packages require a range change and are one or more majors behind (see below).

## Verified
- `bun install` — clean, no errors, all workspaces
- `bun run build` (`tsdown`) — succeeds, output unchanged in size/shape, both before and after the bump

No `lint`, `typecheck`, or `test` scripts exist in this repo (root `package.json` only defines `build`, `dev`, and version/publish scripts), so those steps were skipped, same as prior sweeps.

## Findings (not acted on)

**Majors available** (require a human decision, not bumped):
| package | current | latest | workspace |
|---|---|---|---|
| `@biomejs/biome` | 1.9.4 | 2.5.5 | root |
| `typescript` | 5.9.3 (resolved) | 7.0.2 | root, playground |
| `react` / `react-dom` (peer) | 18.3.1 | 19.2.8 | root, playground, packages/react |
| `astro` | 4.16.19 | 7.1.3 | playground |
| `@astrojs/react` | 3.6.3 | 6.0.1 | playground |
| `@types/react` / `@types/react-dom` | 18.3.x | 19.2.x | playground, packages/react |
| `lorem-ipsum` | 2.0.10 | 3.0.0 | playground |

**CI observations** (`.github/workflows/publish.yml`):
- `actions/checkout@v4` — now 3 majors behind (latest v7). v7's headline change blocks "pwn request" patterns by default for `pull_request_target`/`workflow_run` triggers — not applicable here since this workflow only runs on `release: created`, but still worth picking up for the general hardening/fixes in between.
- `actions/setup-node@v4` — now 3 majors behind (latest v7, released since last week's v6 note).
- `oven-sh/setup-bun@v2` — up to date.

**Security**: GitHub reported 16 Dependabot alerts on `main` after this push (3 high, 9 moderate, 4 low) — up from 13 (3 high, 7 moderate, 3 low) a week ago. Not something this sweep can see into or fix; worth a look at https://github.com/darkroomengineering/hamo/security/dependabot.

**Repo hygiene**: `bun.lock` is in `.gitignore`, so dependency resolution isn't reproducible/pinned across installs — every `bun install` re-resolves to the newest version satisfying each range. Intentional for a published library, but flagging in case that wasn't a deliberate choice.

Not merging — left for review.